### PR TITLE
Update rsa_import.c

### DIFF
--- a/src/pk/rsa/rsa_import.c
+++ b/src/pk/rsa/rsa_import.c
@@ -40,7 +40,7 @@ int rsa_import(const unsigned char *in, unsigned long inlen, rsa_key *key)
    }
 
    /* see if the OpenSSL DER format RSA public key will work */
-   tmpbuf_len = MAX_RSA_SIZE * 8;
+   tmpbuf_len = MAX_RSA_SIZE / 8;
    tmpbuf = XCALLOC(1, tmpbuf_len);
    if (tmpbuf == NULL) {
        err = CRYPT_MEM;


### PR DESCRIPTION
Bug-fix: MAX_RSA_SIZE is the maximum RSA key size in *bits* (as commented in tomcrypt_custom.h), so the proper conversion to bytes (as the argument value to XCALLOC) would be to divide by 8 (bits per byte), not multiply by 8. This excessive allocation of heap memory (32 Kbytes instead of 512 bytes) is readily apparent in memory-constrained environments.